### PR TITLE
Adjusted project settings and unlocked mouse with camera explorer

### DIFF
--- a/Overload-Showroom.ovproject
+++ b/Overload-Showroom.ovproject
@@ -1,12 +1,12 @@
-executable_name=Showroom
 gravity=-9.810000
+executable_name=Showroom
 x_resolution=1600
-multisampling=true
 y_resolution=900
-start_scene=1_Sponza\Sponza.ovscene
+multisampling=true
 fullscreen=false
+start_scene=1_Sponza\Sponza.ovscene
 vsync=true
 samples=4
 opengl_major=4
 opengl_minor=3
-dev_build=true
+dev_build=false

--- a/Scripts/SimpleFPSController.lua
+++ b/Scripts/SimpleFPSController.lua
@@ -17,12 +17,15 @@ function FPSController:OnAwake()
     self.defaultRotation = self.body:GetTransform():GetRotation()
 end
 
-function FPSController:OnStart()
+function FPSController:OnEnable()
     if self.mouseLocked then
         Inputs.LockMouse()
     end
 end
 
+function FPSController:OnDisable()
+    Inputs.UnlockMouse()
+end
 
 function FPSController:OnUpdate(deltaTime)
     -- Toggle mouse lock with Left ALT key

--- a/Scripts/SponzaExplorer.lua
+++ b/Scripts/SponzaExplorer.lua
@@ -54,10 +54,6 @@ function SponzaExplorer:OnAwake()
     self.cameraFade:GetMaterialRenderer():SetUserMatrixElement(0, 0, 0.0)
 end
 
-function SponzaExplorer:OnEnable()
-    Inputs.LockMouse()
-end
-
 function SponzaExplorer:OnUpdate(deltaTime)
     destPosition    = self.destPositions[self.destionationIndex]
     destRotation    = self.destRotations[self.destionationIndex]


### PR DESCRIPTION
# Description
* Project settings got updated to disable the `dev_build` option.
* Mouse cursor is now unlocked during Sponza's cinematic